### PR TITLE
Configure `@stylistic/brace-style` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,13 @@ export default [
       "@stylistic/array-element-newline": ["error", "consistent"],
 
       /**
+       * Enforce consistent brace style for blocks.
+       *
+       * @see {@link https://eslint.style/rules/default/brace-style}
+       */
+      "@stylistic/brace-style": ["error", "1tbs"],
+
+      /**
        * Enforce consistent usage of line breaks between arguments of a function
        * call.
        *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cargosense/eslint-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cargosense/eslint-config",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" :"@cargosense/eslint-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shareable ESLint configuration.",
   "keywords": [
     "eslint-config",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,18 @@ test("loads config and invalidates incorrect syntax", async () => {
 
   const expected = [
     {
+      column: 8,
+      endColumn: 9,
+      endLine: 1,
+      fix: { range: [8, 8], text: "\n" },
+      line: 1,
+      message: "Statement inside of curly braces should be on next line.",
+      messageId: "blockSameLine",
+      nodeType: "Punctuator",
+      ruleId: "@stylistic/brace-style",
+      severity: 2,
+    },
+    {
       column: 10,
       endColumn: 26,
       endLine: 1,
@@ -49,6 +61,18 @@ test("loads config and invalidates incorrect syntax", async () => {
       messageId: "preferFlatMap",
       nodeType: null,
       ruleId: "array-func/prefer-flat-map",
+      severity: 2,
+    },
+    {
+      column: 27,
+      endColumn: 28,
+      endLine: 1,
+      fix: { range: [26, 26], text: "\n" },
+      line: 1,
+      message: "Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.",
+      messageId: "singleLineClose",
+      nodeType: "Punctuator",
+      ruleId: "@stylistic/brace-style",
       severity: 2,
     },
     {
@@ -75,6 +99,6 @@ test("loads config and invalidates incorrect syntax", async () => {
     },
   ];
 
-  assert.strictEqual(errorCount, 4);
+  assert.strictEqual(errorCount, 6);
   assert.deepEqual(messages, expected);
 });


### PR DESCRIPTION
Despite what [the docs](https://eslint.style/rules/default/brace-style) say, `1tbs` is not the default configuration for this rule. `1tbs` is our preferred style, so this change configures the rule thusly.

Good style:

```js
if (some_condition == other_condition) {
  console.log("hooray!");
} else if (some_condition == some_other_condition) {
  console.log("also hooray!");
} else {
  console.log("boo!");
}
```